### PR TITLE
Change inventory defense shield sprite width to 6

### DIFF
--- a/Game/Gui/Inventory/InventoryDefensiveLabel.cs
+++ b/Game/Gui/Inventory/InventoryDefensiveLabel.cs
@@ -34,7 +34,7 @@ namespace UAlbion.Game.Gui.Inventory
                 new ButtonFrame(
                         new HorizontalStack(
                             new FixedSize(6, 8,
-                                new UiSpriteElement<CoreSpriteId>(CoreSpriteId.UiDefensiveValue) { Flags = SpriteFlags.Highlight }),
+                                new UiSpriteElement<CoreSpriteId>(CoreSpriteId.UiDefensiveValue)),
                             new Spacing(1, 0),
                             new UiText(source)
                         )

--- a/Game/Gui/Inventory/InventoryDefensiveLabel.cs
+++ b/Game/Gui/Inventory/InventoryDefensiveLabel.cs
@@ -35,6 +35,7 @@ namespace UAlbion.Game.Gui.Inventory
                         new HorizontalStack(
                             new FixedSize(6, 8,
                                 new UiSpriteElement<CoreSpriteId>(CoreSpriteId.UiDefensiveValue) { Flags = SpriteFlags.Highlight }),
+                            new Spacing(1, 0),
                             new UiText(source)
                         )
                     )

--- a/Game/Gui/Inventory/InventoryDefensiveLabel.cs
+++ b/Game/Gui/Inventory/InventoryDefensiveLabel.cs
@@ -33,7 +33,7 @@ namespace UAlbion.Game.Gui.Inventory
             AttachChild(
                 new ButtonFrame(
                         new HorizontalStack(
-                            new FixedSize(8, 8,
+                            new FixedSize(6, 8,
                                 new UiSpriteElement<CoreSpriteId>(CoreSpriteId.UiDefensiveValue) { Flags = SpriteFlags.Highlight }),
                             new UiText(source)
                         )

--- a/Game/Gui/Inventory/InventoryOffensiveLabel.cs
+++ b/Game/Gui/Inventory/InventoryOffensiveLabel.cs
@@ -34,6 +34,7 @@ namespace UAlbion.Game.Gui.Inventory
                         new HorizontalStack(
                             new FixedSize(8, 8,
                                 new UiSpriteElement<CoreSpriteId>(CoreSpriteId.UiOffensiveValue) { Flags = SpriteFlags.Highlight }),
+                            new Spacing(1, 0),
                             new UiText(source)
                         )
                     )

--- a/Game/Gui/Inventory/InventoryOffensiveLabel.cs
+++ b/Game/Gui/Inventory/InventoryOffensiveLabel.cs
@@ -33,7 +33,7 @@ namespace UAlbion.Game.Gui.Inventory
                 new ButtonFrame(
                         new HorizontalStack(
                             new FixedSize(8, 8,
-                                new UiSpriteElement<CoreSpriteId>(CoreSpriteId.UiOffensiveValue) { Flags = SpriteFlags.Highlight }),
+                                new UiSpriteElement<CoreSpriteId>(CoreSpriteId.UiOffensiveValue)),
                             new Spacing(1, 0),
                             new UiText(source)
                         )


### PR DESCRIPTION
The width of the shield sprite was mistakenly defined as 8 when it should be 6.

Before / after fix picture:

![sprite_size_fix](https://user-images.githubusercontent.com/28017860/87593789-4c207b00-c6ec-11ea-8f89-697aa5db666b.png)