### PR TITLE
Use SavePath consistently

### DIFF
--- a/Game/Assets/SavedGameLocator.cs
+++ b/Game/Assets/SavedGameLocator.cs
@@ -15,7 +15,7 @@ namespace UAlbion.Game.Assets
         public object LoadAsset(AssetKey key, string name, Func<AssetKey, object> loaderFunc)
         {
             var generalConfig = (IGeneralConfig)loaderFunc(new AssetKey(AssetType.GeneralConfig));
-            var filename = Path.Combine(generalConfig.BasePath, generalConfig.ExePath, "SAVES", $"SAVE.{key.Id:D3}");
+            var filename = Path.Combine(generalConfig.BasePath, generalConfig.SavePath, $"SAVE.{key.Id:D3}");
 
             var loader = AssetLoaderRegistry.GetLoader<SavedGame>(FileFormat.SavedGame);
             using var stream = File.Open(filename, FileMode.Open);

--- a/Game/Gui/Menus/PickSaveSlotMenu.cs
+++ b/Game/Gui/Menus/PickSaveSlotMenu.cs
@@ -39,11 +39,11 @@ namespace UAlbion.Game.Gui.Menus
             Remove();
         }
 
-        string BuildSaveFilename(int i)
+        string BuildSaveFilename(ushort i)
         {
+            var key = new AssetKey(AssetType.SavedGame, i);
             var generalConfig = Resolve<IAssetManager>().LoadGeneralConfig();
-            string saveDir = Path.Combine(generalConfig.BasePath, generalConfig.SavePath);
-            return Path.Combine(saveDir, $"SAVE.{i:D3}");
+            return Path.Combine(generalConfig.BasePath, generalConfig.SavePath, $"SAVE.{key.Id:D3}");
         }
 
         protected override void Subscribed()

--- a/Game/State/GameState.cs
+++ b/Game/State/GameState.cs
@@ -146,7 +146,7 @@ namespace UAlbion.Game.State
 
             var key = new AssetKey(AssetType.SavedGame, id);
             var generalConfig = Resolve<IAssetManager>().LoadGeneralConfig();
-            var filename = Path.Combine(generalConfig.BasePath, generalConfig.ExePath, "SAVES", $"SAVE.{key.Id:D3}");
+            var filename = Path.Combine(generalConfig.BasePath, generalConfig.SavePath, $"SAVE.{key.Id:D3}");
 
             using var stream = File.Open(filename, FileMode.Create);
             using var bw = new BinaryWriter(stream);


### PR DESCRIPTION
Saving and loading a game does not always use the property SavePath from the config file.
This patch fixes the issue.
Also fixes the type of the argument for BuildSaveFilename.