### PR TITLE
Improve inventory alignment

### DIFF
--- a/data/game.json
+++ b/data/game.json
@@ -41,7 +41,7 @@
     "Positions":
     {
       "Tom": {
-        "Head":        { "X": 33,  "Y": 5 },
+        "Head":        { "X": 31,  "Y": 5 },
         "Neck":        { "X": 74,  "Y": 14 },
         "RightHand":   { "X": 5,   "Y": 56 },
         "RightFinger": { "X": 5,   "Y": 75 },

--- a/src/Game/Gui/Controls/GroupingFrame.cs
+++ b/src/Game/Gui/Controls/GroupingFrame.cs
@@ -11,7 +11,7 @@ namespace UAlbion.Game.Gui.Controls
             State = ButtonState.Pressed;
         }
 
-        static ColorScheme FrameTheme(ButtonState state)
+        public static ColorScheme FrameTheme(ButtonState state)
         {
             var c = new ColorScheme { Alpha = 0.5f, Corners = CommonColor.Grey8 };
             switch (state)
@@ -32,6 +32,39 @@ namespace UAlbion.Game.Gui.Controls
                     c.TopLeft = CommonColor.Black2;
                     c.BottomRight = CommonColor.White;
                     c.Background = CommonColor.Black2;
+                    break;
+                case ButtonState.HoverPressed:
+                    c.TopLeft = CommonColor.Black2;
+                    c.BottomRight = CommonColor.White;
+                    c.Background = null;
+                    break;
+                default: throw new ArgumentOutOfRangeException();
+            }
+
+            return c;
+        }
+
+        public static ColorScheme FrameThemeBackgroundless(ButtonState state)
+        {
+            var c = new ColorScheme { Alpha = 0.5f, Corners = CommonColor.Grey8 };
+            switch (state)
+            {
+                case ButtonState.Normal:
+                case ButtonState.ClickedBlurred:
+                    c.TopLeft = CommonColor.Black2;
+                    c.BottomRight = CommonColor.White;
+                    c.Background = null;
+                    break;
+                case ButtonState.Hover:
+                    c.TopLeft = CommonColor.White;
+                    c.BottomRight = CommonColor.Black2;
+                    c.Background = null;
+                    break;
+                case ButtonState.Clicked:
+                case ButtonState.Pressed:
+                    c.TopLeft = CommonColor.Black2;
+                    c.BottomRight = CommonColor.White;
+                    c.Background = null;
                     break;
                 case ButtonState.HoverPressed:
                     c.TopLeft = CommonColor.Black2;

--- a/src/Game/Gui/Inventory/InventoryMidPane.cs
+++ b/src/Game/Gui/Inventory/InventoryMidPane.cs
@@ -19,7 +19,7 @@ namespace UAlbion.Game.Gui.Inventory
             var positions = config.Inventory.Positions[_activeCharacter];
             var backgroundStack = new FixedPositionStack();
             var background = new UiSpriteElement<FullBodyPictureId>((FullBodyPictureId)_activeCharacter);
-            backgroundStack.Add(background, 3, 10 - 1);
+            backgroundStack.Add(background, 3, 10 - 1); //subtract 1px because picture starts 1px above frame
 
             var bodyStack = new FixedPositionStack();
             foreach (var bodyPart in positions)

--- a/src/Game/Gui/Inventory/InventoryMidPane.cs
+++ b/src/Game/Gui/Inventory/InventoryMidPane.cs
@@ -20,7 +20,6 @@ namespace UAlbion.Game.Gui.Inventory
             var backgroundStack = new FixedPositionStack();
             var background = new UiSpriteElement<FullBodyPictureId>((FullBodyPictureId)_activeCharacter);
             backgroundStack.Add(background, 3, 10 - 1);
-            AttachChild(backgroundStack);
 
             var bodyStack = new FixedPositionStack();
             foreach (var bodyPart in positions)
@@ -68,7 +67,7 @@ namespace UAlbion.Game.Gui.Inventory
                 labelStack
                 );
 
-            AttachChild(mainStack);
+            AttachChild(new LayerStack(backgroundStack, mainStack));
         }
     }
 }

--- a/src/Game/Gui/Inventory/InventoryMidPane.cs
+++ b/src/Game/Gui/Inventory/InventoryMidPane.cs
@@ -32,8 +32,8 @@ namespace UAlbion.Game.Gui.Inventory
                         InventoryType.Player,
                         (ushort)_activeCharacter,
                         itemSlotId)),
-                    (int)position.X,
-                    (int)position.Y);
+                    (int)position.X + 1, //take frame border into account
+                    (int)position.Y + 1); //take frame border into account
             }
             bodyStack.Add(new Button(new Spacing(128, 168)) { Theme = ButtonTheme.Invisible, Margin = 0, Padding = -1 }
                 .OnClick(() => Raise(new InventorySwapEvent(InventoryType.Player, (ushort)_activeCharacter, ItemSlotId.CharacterBody))), 0, 0);

--- a/src/Game/Gui/Inventory/InventoryMidPane.cs
+++ b/src/Game/Gui/Inventory/InventoryMidPane.cs
@@ -19,9 +19,7 @@ namespace UAlbion.Game.Gui.Inventory
             var positions = config.Inventory.Positions[_activeCharacter];
             var backgroundStack = new FixedPositionStack();
             var background = new UiSpriteElement<FullBodyPictureId>((FullBodyPictureId)_activeCharacter);
-            var backgroundButton = new Button(background) { Theme = ButtonTheme.Invisible }
-                .OnClick(() => Raise(new InventorySwapEvent(InventoryType.Player, (ushort)_activeCharacter, ItemSlotId.CharacterBody)));
-            backgroundStack.Add(backgroundButton, 1, -3);
+            backgroundStack.Add(background, 3, 10 - 1);
             AttachChild(backgroundStack);
 
             var bodyStack = new FixedPositionStack();
@@ -37,9 +35,11 @@ namespace UAlbion.Game.Gui.Inventory
                     (int)position.X,
                     (int)position.Y);
             }
-            bodyStack.Add(new Spacing(0, 164), 0, 0);
+            bodyStack.Add(new Button(new Spacing(128, 168)) { Theme = ButtonTheme.Invisible, Margin = 0, Padding = -1 }
+                .OnClick(() => Raise(new InventorySwapEvent(InventoryType.Player, (ushort)_activeCharacter, ItemSlotId.CharacterBody))), 0, 0);
 
-            var frame = new GroupingFrame(bodyStack);
+            var frame = new GroupingFrame(bodyStack) { Theme = GroupingFrame.FrameThemeBackgroundless, Padding = -1 };
+
             var labelStack = new HorizontalStack(
                 new InventoryOffensiveLabel(_activeCharacter),
                 new Spacing(4, 0),

--- a/src/Game/Gui/Inventory/VisualInventorySlot.cs
+++ b/src/Game/Gui/Inventory/VisualInventorySlot.cs
@@ -34,7 +34,9 @@ namespace UAlbion.Game.Gui.Inventory
 
             if (!slotId.Slot.IsSpecial())
             {
-                _size = slotId.Slot.IsBodyPart() ? new Vector2(16, 16) : new Vector2(16, 20);
+                _size = slotId.Slot.IsBodyPart() ?
+                    new Vector2(18, 18) : //16x16 surrounded by 1px borders
+                    new Vector2(16, 20);
                 _sprite = new UiSpriteElement<AssetId>(ItemSpriteId.Nothing.ToAssetId())
                 {
                     SubId = (int)ItemSpriteId.Nothing
@@ -45,7 +47,7 @@ namespace UAlbion.Game.Gui.Inventory
                             new LayerStack(
                                 _sprite,
                                 _overlay),
-                            0, 0, 16, 16)
+                            1, 1, 16, 16) //16x16 surrounded by 1px borders
                         .Add(text, 0, 20 - 9, 16, 9))
                     {
                         Padding = -1,


### PR DESCRIPTION
Various small improvements of the inventory alignment:

- Align character background images like in the original game (matching the background pattern)
- Enlarge body item slots to 18x18 to account for the 1px frame (its contents are 16x16px)
- Fix Tom's head slot position
- Fix render order bug that made frame disappear partially at times

![ualbion_inv20](https://user-images.githubusercontent.com/28017860/88561352-96302780-d02f-11ea-9c10-ae888d8750ea.png)
