### PR TITLE
Fix GOG_EXTR.bat, adjust README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,32 +51,33 @@ Planned improvements / changes from the original gameplay:
 ## Getting started
 
 1. Configure `data/config.json` to set the paths for the files from the original game (currently only version v1.38 where MAIN.EXE is 1,109,655 bytes is supported). If you're running the GOG version, you'll want to mount the `game.gog` file (it's just a .bin format CD image) and then copy the ALBION directory into your UAlbion folder.
-1. To compile and run the project, open `ualbion.sln` in the C# IDE of your choice or run `./run.sh` in Linux / `run.bat` in Windows. Any extra parameters to `run` will be passed through to UAlbion, `--help` will show the available options.
-    - To show available options: run -h
-    - To run with Vulkan: run -vk
-    - To run with OpenGL: run -gl
-    - To run with Direct3D: run -d3d
+1. To compile and run the project, open `ualbion.sln` in the C# IDE of your choice or run `./run.sh` in Linux (ensure `dotnet-host`, `dotnet-runtime` and `dotnet-sdk` are installed) or `run.bat` in Windows. Any extra parameters to `run` will be passed through to UAlbion, `--help` will show the available options.
+    - To show available options: `run -h`
+    - To run with Vulkan: `run -vk`
+    - To run with OpenGL: `run -gl`
+    - To run with Direct3D: `run -d3d`
 
 To extract the required game files from the GOG version of the game:
 
 ### Linux:
-1. Ensure wine, dosbox, dotnet-host, dotnet-runtime and dotnet-sdk are installed
-1. Download the Windows installer for Albion from GOG
-1. Run the installer using wine (`wine setup_albion_1.38_\(28043\).exe`)
-1. Navigate to installed path (if you installed to the default path, `cd ~/.wine/drive_c/GOG\ Games/Albion/`)
+1. Ensure `wine` and `dosbox` are installed
+1. Download the [Albion installer for Windows from GOG](https://www.gog.com/game/albion)
+1. Run the installer using wine (`wine setup_albion_1.38_\(28043\).exe`). Note that the installer may show some errors, but if the game can be launched in the end, it's okay.
 1. Run `dosbox`
-1. Run the following commands in dosbox to extract the data files: (replace ~/ualbion with wherever you cloned the ualbion repository)
-    1. mount c ~/ualbion
-    1. C:\Tools\GOG_EXTR.BAT
+1. Run the following commands in dosbox to extract the data files: (Replace `~/ualbion` with wherever you cloned the ualbion repository. Replace `~/.wine/drive_c/GOG Games/Albion/` with wherever you installed your GOG version of Albion. Note the double quotes (`"`), they are necessary if your path contains spaces.)
+    1. `mount C "~/ualbion"`
+    1. `mount D "~/.wine/drive_c/GOG Games/Albion/"`
+    1. `C:\src\Tools\GOG_EXTR.BAT`
 
 ### Windows:
-1. Download the Albion installer from GOG
+1. Download the [Albion installer from GOG](https://www.gog.com/game/albion)
 1. Run installer
-1. Open the Albion install directory in file explorer (e.g. C:\GOG Games\Albion)
-1. Go into the DOSBOX directory and run DOSBOX.exe
-1. Run the following commands in dosbox to extract the data files: (replace C:\Git\ualbion with wherever you cloned the ualbion repository. If the path contains spaces, you may need to surround it with double quotes.)
-    1. mount c C:\Git\ualbion
-    1. C:\Tools\GOG_EXTR.BAT
+1. Open the Albion install directory in file explorer (e.g. `C:\GOG Games\Albion`)
+1. Go into the `DOSBOX` directory and run `DOSBOX.exe`
+1. Run the following commands in dosbox to extract the data files: (Replace `C:\Git\ualbion` with wherever you cloned the ualbion repository. Replace `C:\GOG Games\Albion` with wherever you installed your GOG version of Albion. Note the double quotes (`"`), they are necessary if your path contains spaces.)
+    1. `mount C "C:\Git\ualbion"`
+    1. `mount D "C:\GOG Games\Albion"`
+    1. `C:\src\Tools\GOG_EXTR.BAT`
 
 ## Attributions
 Many thanks to Florian Ziesche and the other contributers to the [freealbion wiki](https://github.com/freealbion/freealbion/wiki) for their efforts in discovering and documenting the Albion file formats.

--- a/README.md
+++ b/README.md
@@ -50,16 +50,13 @@ Planned improvements / changes from the original gameplay:
 
 ## Getting started
 
-1. Configure `data/config.json` to set the paths for the files from the original game (currently only version v1.38 where MAIN.EXE is 1,109,655 bytes is supported). If you're running the GOG version, you'll want to mount the `game.gog` file (it's just a .bin format CD image) and then copy the ALBION directory into your UAlbion folder.
-1. To compile and run the project, open `ualbion.sln` in the C# IDE of your choice or run `./run.sh` in Linux (ensure `dotnet-host`, `dotnet-runtime` and `dotnet-sdk` are installed) or `run.bat` in Windows. Any extra parameters to `run` will be passed through to UAlbion, `--help` will show the available options.
-    - To show available options: `run -h`
-    - To run with Vulkan: `run -vk`
-    - To run with OpenGL: `run -gl`
-    - To run with Direct3D: `run -d3d`
+### Game data
 
-To extract the required game files from the GOG version of the game:
+You need to have the original Albion game files. These days, Albion can be bought cheaply on [GOG](https://www.gog.com/game/albion).
 
-### Linux:
+If you have the GOG version of the game, extract the required game files as following:
+
+#### Linux:
 1. Ensure `wine` and `dosbox` are installed
 1. Download the [Albion installer for Windows from GOG](https://www.gog.com/game/albion)
 1. Run the installer using wine (`wine setup_albion_1.38_\(28043\).exe`). Note that the installer may show some errors, but if the game can be launched in the end, it's okay.
@@ -69,7 +66,7 @@ To extract the required game files from the GOG version of the game:
     1. `mount D "~/.wine/drive_c/GOG Games/Albion/"`
     1. `C:\src\Tools\GOG_EXTR.BAT`
 
-### Windows:
+#### Windows:
 1. Download the [Albion installer from GOG](https://www.gog.com/game/albion)
 1. Run installer
 1. Open the Albion install directory in file explorer (e.g. `C:\GOG Games\Albion`)
@@ -78,6 +75,16 @@ To extract the required game files from the GOG version of the game:
     1. `mount C "C:\Git\ualbion"`
     1. `mount D "C:\GOG Games\Albion"`
     1. `C:\src\Tools\GOG_EXTR.BAT`
+
+If you did not do the above steps and want to select your game files manually, configure `data/config.json` to set the paths for the files from the original game (currently only version v1.38 where `MAIN.EXE` is 1,109,655 bytes and has a SHA256 hash of `476227b0391cf3452166b7a1d52b012ccf6c86bc9e46886dafbed343e9140710` is supported). If you're running the GOG version, you'll want to mount the `game.gog` file (it's just a raw binary dump of the CD contents) using CDemu and then copy the ALBION directory into your UAlbion folder.
+
+### Compile and run
+
+To compile and run the project, open `ualbion.sln` in the C# IDE of your choice or run `./run.sh` in Linux (ensure `dotnet-host`, `dotnet-runtime` and `dotnet-sdk` are installed) or `run.bat` in Windows. Any extra parameters to `run` will be passed through to UAlbion, `--help` will show the available options.
+- To show available options: `run -h`
+- To run with Vulkan: `run -vk`
+- To run with OpenGL: `run -gl`
+- To run with Direct3D: `run -d3d`
 
 ## Attributions
 Many thanks to Florian Ziesche and the other contributers to the [freealbion wiki](https://github.com/freealbion/freealbion/wiki) for their efforts in discovering and documenting the Albion file formats.

--- a/src/Tools/GOG_EXTR.bat
+++ b/src/Tools/GOG_EXTR.bat
@@ -1,33 +1,61 @@
 @echo off
-if not exist ualbion.sln goto badpath
 
-imgmount d game.ins -t iso -fs iso
-if errorlevel 0 goto mountok
-imgmount d ..\game.ins -t iso -fs iso
-:mountok
+if not exist "C:\src\ualbion.sln" goto c_dir_err
+goto c_dir_ok
 
-D:
-cd ALBION
-mkdir C:\ALBION
-mkdir C:\ALBION\DRIVERS
-mkdir C:\ALBION\SAVES
-mkdir C:\ALBION\CD
-mkdir C:\ALBION\CD\XLDLIBS
-mkdir C:\ALBION\CD\XLDLIBS\INITIAL
-mkdir C:\ALBION\CD\XLDLIBS\ENGLISH
-mkdir C:\ALBION\CD\XLDLIBS\GERMAN
-mkdir C:\ALBION\CD\XLDLIBS\FRENCH
-
-copy ROOT\MAIN.EXE C:\ALBION
-copy DRIVERS\ALBISND.OPL C:\ALBION\DRIVERS
-copy XLDLIBS\*.* C:\ALBION\CD\XLDLIBS
-copy XLDLIBS\INITIAL\*.* C:\ALBION\CD\XLDLIBS\INITIAL
-copy XLDLIBS\ENGLISH\*.* C:\ALBION\CD\XLDLIBS\ENGLISH
-copy XLDLIBS\GERMAN\*.* C:\ALBION\CD\XLDLIBS\GERMAN
-copy XLDLIBS\FRENCH\*.* C:\ALBION\CD\XLDLIBS\FRENCH
+:c_dir_err
+echo Error: C drive must be mounted to point at the ualbion main directory.
+echo E.g. mount C "C:\Git\ualbion"
 goto end
 
-:badpath
-echo C drive must be mounted to point at the ualbion depot directory.
+:c_dir_ok
+
+if not exist "D:\game.ins" goto d_dir_err
+if not exist "D:\game.gog" goto d_dir_err
+goto d_dir_ok
+
+:d_dir_err
+echo Error: D drive must be mounted to point at the Albion GOG installation.
+echo E.g. mount D "C:\Program Files\Albion"
+goto end
+
+:d_dir_ok
+
+imgmount E D:\game.ins -t iso -fs iso
+if errorlevel 1 goto mount_err
+if not exist E:\ALBION goto mount_err
+goto mount_ok
+
+:mount_err
+echo Error: Could not mount Albion CD image, please verify your game installation.
+goto end
+
+:mount_ok
+
+set DST=C:\ALBION
+mkdir %DST%
+mkdir %DST%\DRIVERS
+mkdir %DST%\SAVES
+mkdir %DST%\CD
+mkdir %DST%\CD\XLDLIBS
+mkdir %DST%\CD\XLDLIBS\INITIAL
+mkdir %DST%\CD\XLDLIBS\ENGLISH
+mkdir %DST%\CD\XLDLIBS\GERMAN
+mkdir %DST%\CD\XLDLIBS\FRENCH
+
+set SRC=E:\ALBION
+copy %SRC%\ROOT\MAIN.EXE %DST%
+copy %SRC%\DRIVERS\ALBISND.OPL %DST%\DRIVERS
+copy %SRC%\XLDLIBS\*.* %DST%\CD\XLDLIBS
+copy %SRC%\XLDLIBS\INITIAL\*.* %DST%\CD\XLDLIBS\INITIAL
+if exist %SRC%\XLDLIBS\ENGLISH copy %SRC%\XLDLIBS\ENGLISH\*.* %DST%\CD\XLDLIBS\ENGLISH
+if exist %SRC%\XLDLIBS\GERMAN copy %SRC%\XLDLIBS\GERMAN\*.* %DST%\CD\XLDLIBS\GERMAN
+if exist %SRC%\XLDLIBS\FRENCH copy %SRC%\XLDLIBS\FRENCH\*.* %DST%\CD\XLDLIBS\FRENCH
+
+if not exist %SRC%\XLDLIBS\ENGLISH echo Note: No English language files found.
+if not exist %SRC%\XLDLIBS\GERMAN echo Note: No German language files found.
+if not exist %SRC%\XLDLIBS\FRENCH echo Note: No French language files found.
+
+echo Successfully copied game file to ualbion.
 
 :end

--- a/src/Tools/GOG_EXTR.bat
+++ b/src/Tools/GOG_EXTR.bat
@@ -16,7 +16,7 @@ goto d_dir_ok
 
 :d_dir_err
 echo Error: D drive must be mounted to point at the Albion GOG installation.
-echo E.g. mount D "C:\Program Files\Albion"
+echo E.g. mount D "C:\GOG Games\Albion"
 goto end
 
 :d_dir_ok


### PR DESCRIPTION
To me, `README.md` was confusing to follow when I initially cloned the repository. The instructions to extract game data didn't work. In addition, the source tree was recently moved into the `src` subfolder which caused breakage in GOG_EXTR.bat and its documentation.

This PR resolves all these problems. In addition, the entire `Getting Started` section is rearranged and reworked to more easily guide users who want to run the game themselves.