### PR TITLE
Fix for GOG_EXTR.bat script

### DIFF
--- a/src/Tools/GOG_EXTR.bat
+++ b/src/Tools/GOG_EXTR.bat
@@ -1,6 +1,6 @@
 @echo off
 
-if not exist "C:\src\ualbion.sln" goto c_dir_err
+if not exist "C:\ualbion.sln" goto c_dir_err
 goto c_dir_ok
 
 :c_dir_err


### PR DESCRIPTION
Fix for GOG_EXTR.bat script, that was searching for ualbion.sln in wrong directory and initialization script was failing due to that.